### PR TITLE
Allow None values for specific options to be passed through

### DIFF
--- a/qiskit_ibm_runtime/options/utils.py
+++ b/qiskit_ibm_runtime/options/utils.py
@@ -52,13 +52,13 @@ def set_default_error_levels(
             options["resilience_level"] = default_resilience_level
     return options
 
-
-def _remove_dict_none_values(in_dict: dict) -> None:
+def _remove_dict_none_values(in_dict: dict, allowed_none_keys: set = None):
+    allowed_none_keys = allowed_none_keys or {}
     for key, val in list(in_dict.items()):
-        if val is None:
+        if val is None and key not in allowed_none_keys:
             del in_dict[key]
         elif isinstance(val, dict):
-            _remove_dict_none_values(val)
+            _remove_dict_none_values(val, allowed_none_keys=allowed_none_keys)
 
 
 def _to_obj(cls_, data):  # type: ignore


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Hack to fix issue with options values that should be passed through is set to None

### Details and comments

Currently these are shots, samples, shots_per_sample, zne_extrapolator, pec_max_overhead